### PR TITLE
Make portable across different UNIX like

### DIFF
--- a/src/test/utest/framework/filter-expected.sh
+++ b/src/test/utest/framework/filter-expected.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This little script generates the 'expected' output for mapdb-related tests.
 # The following modifications are done:

--- a/tool/backtrace
+++ b/tool/backtrace
@@ -1,4 +1,4 @@
-#! /usr/bin/perl -W
+#!/usr/bin/env -S perl -W
 
 use Math::BigInt;
 use strict;

--- a/tool/checkinitcalls
+++ b/tool/checkinitcalls
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 
 # we use BigInts for handling 64-bit values on IA32 systems
 

--- a/tool/circular
+++ b/tool/circular
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 $, = ' ';		# set output field separator
 $\ = "\n";		# set output record separator
 

--- a/tool/configstat
+++ b/tool/configstat
@@ -1,4 +1,4 @@
-#! /usr/bin/perl -W
+#!/usr/bin/env -S perl -W
 
 use strict;
 

--- a/tool/gen_kconfig
+++ b/tool/gen_kconfig
@@ -1,4 +1,4 @@
-#! /usr/bin/perl -W
+#!/usr/bin/env -S perl -W
 
 use strict;
 

--- a/tool/gendotdeps
+++ b/tool/gendotdeps
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 
 use strict;
 use Getopt::Long;

--- a/tool/kconfig/scripts/gcc-goto.sh
+++ b/tool/kconfig/scripts/gcc-goto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # SPDX-License-Identifier: GPL-2.0
 # Test for gcc 'asm goto' support
 # Copyright (C) 2010, Jason Baron <jbaron@redhat.com>

--- a/tool/kconfig/scripts/kconfig/gconf-cfg.sh
+++ b/tool/kconfig/scripts/kconfig/gconf-cfg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # SPDX-License-Identifier: GPL-2.0
 
 PKG="gtk+-2.0 gmodule-2.0 libglade-2.0"

--- a/tool/kconfig/scripts/kconfig/mconf-cfg.sh
+++ b/tool/kconfig/scripts/kconfig/mconf-cfg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # SPDX-License-Identifier: GPL-2.0
 
 PKG="ncursesw"

--- a/tool/kconfig/scripts/kconfig/nconf-cfg.sh
+++ b/tool/kconfig/scripts/kconfig/nconf-cfg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # SPDX-License-Identifier: GPL-2.0
 
 PKG="ncursesw menuw panelw"

--- a/tool/kconfig/scripts/kconfig/qconf-cfg.sh
+++ b/tool/kconfig/scripts/kconfig/qconf-cfg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # SPDX-License-Identifier: GPL-2.0
 
 PKG="Qt5Core Qt5Gui Qt5Widgets"

--- a/tool/kobjdeps
+++ b/tool/kobjdeps
@@ -1,4 +1,4 @@
-#! /usr/bin/perl -W
+#!/usr/bin/env -S perl -W
 #
 # Adam Lackorzynski <adam@l4re.org>
 #

--- a/tool/move-if-change
+++ b/tool/move-if-change
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Like mv $1 $2, but if the files are the same, just delete $1.
 # Status is 0 if $2 is changed, 1 otherwise.
 quiet=

--- a/tool/parsedeps
+++ b/tool/parsedeps
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 
 use strict;
 

--- a/tool/preprocess/src/preprocess
+++ b/tool/preprocess/src/preprocess
@@ -1,4 +1,4 @@
-#! /usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 # -*- perl -*-
 
 #

--- a/tool/preprocess/test/combine.pl
+++ b/tool/preprocess/test/combine.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 
 print '
 INTERFACE:

--- a/tool/showdeps
+++ b/tool/showdeps
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -W
 
 $mode = "ascii";
 $mode = shift @ARGV if ($#ARGV > -1);

--- a/tool/split_config
+++ b/tool/split_config
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 


### PR DESCRIPTION
Shebangs like  
`#!/usr/bin/perl` and `#!/usr/bin/sh`  
are not compatible with certain UNIX operating systems (like for example NixOS)  

This PR aims to make building fiasco available to more UNIX like operating systems.

[Relevant Article on `!#/usr/bin/env`](https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html)