### PR TITLE
Enable compilation using LLVM toolchain

### DIFF
--- a/src/Makerules.TCBOFFSET
+++ b/src/Makerules.TCBOFFSET
@@ -14,7 +14,9 @@ tcboffset.o: tcboffset_in.h
 
 tcboffset.bin: tcboffset.o
 	$(LINK_MESSAGE)
-	$(VERBOSE)$(OBJCOPY) -j .e_length -j .offsets --adjust-section-vma .offsets=32 -Obinary $< $@
+	$(VERBOSE)$(OBJCOPY) -j .e_length -Obinary $< elength.bin
+	$(VERBOSE)$(OBJCOPY) -j .offsets -Obinary $< offsets.bin
+	cat elength.bin offsets.bin > $@
 
 
 clean-TCBOFFSET:


### PR DESCRIPTION
llvm-objcopy does not support --adjust-section-vma option which was used by the
build system in a somewhat hacky way as a primitive linker. Since the result is
precisely the two sections in their binary form concatenated,
--adjust-section-vma can be avoided by converting the two sections to binary
separately and then concatenating them.

This change also makes the code more robust because the offset is no longer
hardcoded.

"Contribution covered by the CLA"
