### PR TITLE
arm: cortex-r52: add L1 cache way segregation configuration

### DIFF
--- a/src/kern/arm/32/cpu-arm-32.cpp
+++ b/src/kern/arm/32/cpu-arm-32.cpp
@@ -220,6 +220,13 @@ PUBLIC static
 void
 Cpu::init_sctlr()
 {
+
+  // Updates to the Cache Segregation Control Register are only permitted before
+  // the caches have ever been enabled following a system reset, otherwise the
+  // update is ignored
+  if constexpr (TAG_ENABLED(arm_cortex_r52))
+    asm volatile("mcr p15, 1, %0, c9, c1, 0" : : "r" (Imp_csctlr)); // IMP_CSCTLR
+
   Mem::dsb();
   asm volatile("mcr p15, 4, %[control], c1, c0, 0" // HSCTLR
       : : [control] "r" (Hsctlr));

--- a/src/kern/arm/Kconfig
+++ b/src/kern/arm/Kconfig
@@ -556,6 +556,30 @@ config ARM_FAST_INTERRUPTS
 
 	  If unsure, say N.
 
+config ARM_ICACHE_FLASH_WAYS
+	int "L1 instruction cache ways allocation for Flash interface"
+	depends on ARM_CORTEX_R52 && CPU_VIRT
+	range 0 4
+	default 0
+	help
+	  On Cortex-R52, the L1 instruction cache supports segregation of cache ways
+	  between the Flash and AXIM interfaces. This option allows configuring how
+	  many cache ways are allocated to each interface. By default (reset value),
+	  all instruction cache ways are assigned to the AXIM interface. Adjusting
+	  this setting can optimize performance based on memory access patterns.
+
+config ARM_DCACHE_FLASH_WAYS
+	int "L1 data cache ways allocation for Flash interface"
+	depends on ARM_CORTEX_R52 && CPU_VIRT
+	range 0 4
+	default 0
+	help
+	  On Cortex-R52, the L1 data cache supports segregation of cache ways
+	  between the Flash and AXIM interfaces. This option allows configuring how
+	  many cache ways are allocated to each interface. By default (reset value),
+	  all data cache ways are assigned to the AXIM interface. Adjusting
+	  this setting can optimize performance based on memory access patterns.
+
 # SECTION: COMPILING
 
 config THUMB2

--- a/src/kern/arm/bsp/s32z/platform_control-arm-s32z.cpp
+++ b/src/kern/arm/bsp/s32z/platform_control-arm-s32z.cpp
@@ -28,9 +28,6 @@ Platform_control::amp_ap_early_init()
   asm volatile ("mcr p15, 0, %0, c9, c1, 0" : : "r"(tcm_base));
   asm volatile ("mcr p15, 0, %0, c9, c1, 1" : : "r"(tcm_base | 0x00100000));
   asm volatile ("mcr p15, 0, %0, c9, c1, 2" : : "r"(tcm_base | 0x00200000));
-
-  // Split cache ways between AXIF and AXIM
-  asm volatile ("mcr p15, 1, %0, c9, c1, 0" : : "r"(0x202));
 }
 
 // ------------------------------------------------------------------------

--- a/src/kern/arm/config-arm.cpp
+++ b/src/kern/arm/config-arm.cpp
@@ -130,6 +130,19 @@ public:
   };
 };
 
+// -----------------------------------------------------------------------
+INTERFACE [arm && cpu_virt && arm_cortex_r52]:
+
+EXTENSION class Config
+{
+public:
+  enum
+  {
+    Icache_flash_ways = CONFIG_ARM_ICACHE_FLASH_WAYS,
+    Dcache_flash_ways = CONFIG_ARM_DCACHE_FLASH_WAYS,
+  };
+};
+
 //---------------------------------------------------------------------------
 IMPLEMENTATION [arm]:
 

--- a/src/kern/arm/cpu-arm.cpp
+++ b/src/kern/arm/cpu-arm.cpp
@@ -340,6 +340,25 @@ public:
   };
 };
 
+// ------------------------------------------------------------------------
+INTERFACE [arm && cpu_virt && arm_cortex_r52]:
+
+EXTENSION class Cpu
+{
+  enum {
+    Imp_csctlr = (Config::Dcache_flash_ways << 0)  // DFLW
+               | (Config::Icache_flash_ways << 8), // IFLW
+  };
+};
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && cpu_virt && !arm_cortex_r52]:
+
+EXTENSION class Cpu
+{
+  enum { Imp_csctlr = 0 };
+};
+
 // -------------------------------------------------------------------------------
 INTERFACE [arm]:
 


### PR DESCRIPTION
Introduce support for configuring L1 cache way segregation on Cortex-R52 for both instruction and data caches. This feature allows splitting cache ways between the Flash and AXIM interfaces to optimize performance based on memory access patterns.

Previously, this configuration was applied in both the kernel and bootstrap platform init hooks. It is now centralized in the kernel to maintain a single point of truth and simplify platform initialization.

See https://github.com/kernkonzept/bootstrap/pull/4
