### PR TITLE
Make `Max_iommus` configurable on x86 like it is on ARM, improve corresponding panic message

### DIFF
--- a/src/kern/ia32/Kconfig
+++ b/src/kern/ia32/Kconfig
@@ -131,3 +131,7 @@ config TSC_UNIFIED
 
 	  Unfortunately we cannot panic in that case because QEMU does not
 	  support this CPU feature in TCG.
+
+config IA32_IOMMU_MAX
+	int "Maxmimum number of IOMMUs"
+	default 16 if IOMMU

--- a/src/kern/ia32/intel_iommu.cpp
+++ b/src/kern/ia32/intel_iommu.cpp
@@ -22,7 +22,7 @@ class Io_mmu :
 {
 public:
   /// Maximum number of IOMMUs.
-  enum { Max_iommus = 16 };
+  enum { Max_iommus = CONFIG_IA32_IOMMU_MAX };
 
   /// Command and status register bits
   enum Cmd_bits
@@ -916,7 +916,7 @@ Intel::Io_mmu::init(Cpu_number cpu)
       ++units;
 
   if (units > Max_iommus)
-    panic("Cannot handle more than %d IOMMUs", Max_iommus);
+    panic("Cannot handle more than %d IOMMUs (%u found)", Max_iommus, units);
 
   // need to take a copy of the DMAR into the kernel AS as the ACPI
   // are mapped only into IDLE AS!


### PR DESCRIPTION
This change
* Adds a new Kconfig entry (IA32_IOMMU_MAX) akin to ARM_IOMMU_MAX on ARM
* Uses the new Kconfig entry instead of the hardcoded value 16
* Includes the number of discovered IOMMUs in the corresponding panic message