### PR TITLE
arm: bsp: add NXP S32N5 platform support

### DIFF
--- a/src/kern/arm/bsp/s32n/Kconfig
+++ b/src/kern/arm/bsp/s32n/Kconfig
@@ -1,0 +1,98 @@
+# Copyright 2023-2025 NXP
+# SPDX-License-Identifier: MIT
+
+# PF: S32N
+# PFDESCR: NXP S32N
+# PFSELECT: CAN_ARM_CPU_CORTEX_R52 ARM_GIC HAVE_ARM_GICV3 HAS_PLAT_AMP_OPTION
+# PFDEPENDS: ARM
+
+choice
+	prompt "NXP S32N"
+	default PF_S32N5
+
+config PF_S32N5
+	bool "NXP S32N5"
+	depends on PF_S32N
+	help
+	  Choose for NXP S32N5 series.
+
+endchoice # PF_S32N
+
+choice
+	prompt "RTU config"
+	default PF_S32N_RTU_0
+
+config PF_S32N_RTU_0
+	bool "RTU0"
+	depends on PF_S32N5
+
+config PF_S32N_RTU_1
+	bool "RTU1"
+	depends on PF_S32N5
+
+config PF_S32N_RTU_2
+	bool "RTU2"
+	depends on PF_S32N5
+
+config PF_S32N_RTU_3
+	bool "RTU3"
+	depends on PF_S32N5
+
+endchoice # RTU
+
+choice
+	prompt "RTU Cluster 0 configuration"
+	default PF_S32N_RTU_CL0_LOCKSTEP
+
+config PF_S32N_RTU_CL0_DISABLED
+	bool "disabled"
+
+config PF_S32N_RTU_CL0_LOCKSTEP
+	bool "lockstep"
+
+config PF_S32N_RTU_CL0_SPLIT
+	bool "split mode"
+
+endchoice # RTU Cluster 0
+
+choice
+	prompt "RTU Cluster 1 configuration"
+	default PF_S32N_RTU_CL1_LOCKSTEP
+
+config PF_S32N_RTU_CL1_DISABLED
+	bool "disabled"
+
+config PF_S32N_RTU_CL1_LOCKSTEP
+	bool "lockstep"
+
+config PF_S32N_RTU_CL1_SPLIT
+	bool "split mode"
+
+endchoice # RTU Cluster 1
+
+config PF_S32N_AUTO_RAM_BASE
+	bool "Automatically choose RAM_BASE"
+	default y
+	help
+	  Use default RAM base address. Uses CRAM0 of the respective cluster:
+
+	  RTU0: 0x39580000
+	  RTU1: 0x3b580000
+	  RTU2: 0x3d580000
+	  RTU3: 0x3f580000
+
+config PF_S32N_MANUAL_RAM_BASE
+	hex "Custom RAM_BASE"
+	depends on !PF_S32N_AUTO_RAM_BASE
+	default 0x39580000 if PF_S32N_RTU_0
+	default 0x3b580000 if PF_S32N_RTU_1
+	default 0x3d580000 if PF_S32N_RTU_2
+	default 0x3f580000 if PF_S32N_RTU_3
+
+config PF_S32N_MRU
+	bool "MRU interrupt support"
+	default y
+	help
+	  This driver enables support for receiving interrupts from MRU instances
+	  that are connected as PPI to each core. Each MRU channel is available as
+	  dedicated interrupt, starting from 1024.

--- a/src/kern/arm/bsp/s32n/Modules
+++ b/src/kern/arm/bsp/s32n/Modules
@@ -1,0 +1,29 @@
+# Copyright 2023-2025 NXP
+# SPDX-License-Identifier: MIT
+
+# vim:set ft=make:
+
+OBJECTS_LIBUART       += uart_dcc-v6.o
+CXXFLAGS_uart-libuart += $(call LIBUART_UART, dcc-v6, dcc_v6)
+
+PREPROCESS_PARTS      += generic_tickless_idle arm_generic_timer pic_gic
+INTERFACES_KERNEL     += generic_timer irq_mgr_multi_chip
+INTERFACES_DRIVERS    += mru
+
+RAM_PHYS_BASE         := $(strip $(if $(CONFIG_PF_S32N_AUTO_RAM_BASE), \
+                            $(if $(CONFIG_PF_S32N_RTU_0),0x39580000,\
+                                $(if $(CONFIG_PF_S32N_RTU_1),0x3b580000,\
+                                    $(if $(CONFIG_PF_S32N_RTU_2),0x3d580000,0x3f580000))),\
+                          $(CONFIG_PF_S32N_MANUAL_RAM_BASE)))
+
+amp_node_IMPL         := amp_node amp_node-arm-s32n
+config_IMPL           += config-arm-s32n
+kmem_alloc_IMPL       += kmem_alloc-arm-s32n
+mem_layout_IMPL       += mem_layout-arm-s32n
+mru_IMPL              += mru mru-arm-s32n
+pic_IMPL              += pic-gic pic-arm-s32n
+timer_IMPL            += timer-arm-generic timer-arm-generic-s32n
+timer_tick_IMPL       += timer_tick-single-vector
+reset_IMPL            += reset-arm-s32n
+clock_IMPL            += clock-arm-generic
+platform_control_IMPL += platform_control-arm-s32n

--- a/src/kern/arm/bsp/s32n/amp_node-arm-s32n.cpp
+++ b/src/kern/arm/bsp/s32n/amp_node-arm-s32n.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * Core configuration for AMP:
+ *
+ *   0   1   2   3     first  max
+ *   s   s   s   s     0      4
+ *   s   s   _ls__     0      3
+ *   _ls__   s   s     0      3
+ *   _ls__   _ls__     0      2
+ *   s   s   -   -     0      2
+ *   -   -   s   s     2      2
+ *
+ *   s: split-lock, ls: lock-step, -: disabled
+ *   all other combinations don't apply for AMP
+ */
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && amp && pf_s32n && pf_s32n_rtu_cl0_split && pf_s32n_rtu_cl1_split]:
+
+EXTENSION class Amp_node
+{
+public:
+  static constexpr unsigned Max_cores = 4;
+};
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && amp && pf_s32n && pf_s32n_rtu_cl0_split && pf_s32n_rtu_cl1_lockstep]:
+
+EXTENSION class Amp_node
+{
+public:
+  static constexpr unsigned Max_cores = 3;
+};
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && amp && pf_s32n && pf_s32n_rtu_cl0_lockstep && pf_s32n_rtu_cl1_split]:
+
+EXTENSION class Amp_node
+{
+public:
+  static constexpr unsigned Max_cores = 3;
+};
+
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && amp && pf_s32n && pf_s32n_rtu_cl0_lockstep && pf_s32n_rtu_cl1_lockstep]:
+
+EXTENSION class Amp_node
+{
+public:
+  static constexpr unsigned Max_cores = 2;
+};
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && amp && pf_s32n && pf_s32n_rtu_cl0_split && pf_s32n_rtu_cl1_disabled]:
+
+EXTENSION class Amp_node
+{
+public:
+  static constexpr unsigned Max_cores = 2;
+};
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && amp && pf_s32n && pf_s32n_rtu_cl0_disabled && pf_s32n_rtu_cl1_split]:
+
+EXTENSION class Amp_node
+{
+public:
+  static constexpr unsigned Max_cores = 2;
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32n && pf_s32n_rtu_cl0_disabled]:
+
+IMPLEMENT_OVERRIDE static constexpr
+Amp_phys_id
+Amp_node::first_node()
+{ return Amp_phys_id(2); }
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && amp && pf_s32n]:
+
+#include "processor.h"
+
+IMPLEMENT inline ALWAYS_INLINE NEEDS["processor.h"]
+FIASCO_PURE Amp_phys_id
+Amp_node::phys_id()
+{
+  // Aff0: 0..1 - core in cluster
+  // Aff1: 0..1 - cluster in RTU
+  // Aff2: 0..3 - RTU in SoC, not used since we run in a single RTU
+  unsigned mpidr = cxx::int_value<Cpu_phys_id>(Proc::cpu_id());
+  return Amp_phys_id(((mpidr & 0x100) >> 7) | (mpidr & 0x1));
+}

--- a/src/kern/arm/bsp/s32n/config-arm-s32n.cpp
+++ b/src/kern/arm/bsp/s32n/config-arm-s32n.cpp
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+INTERFACE [arm && pf_s32n5]:
+
+#define TARGET_NAME "NXP S32N5"

--- a/src/kern/arm/bsp/s32n/kmem_alloc-arm-s32n.cpp
+++ b/src/kern/arm/bsp/s32n/kmem_alloc-arm-s32n.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32n && pf_s32n_rtu_0]:
+
+EXTENSION class Kmem_alloc
+{
+  static constexpr unsigned long Rtu_heap_region_start = 0x39580000;
+  static constexpr unsigned long Rtu_heap_region_end   = 0x39ffffff;
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32n && pf_s32n_rtu_1]:
+
+EXTENSION class Kmem_alloc
+{
+  static constexpr unsigned long Rtu_heap_region_start = 0x3b580000;
+  static constexpr unsigned long Rtu_heap_region_end   = 0x3bffffff;
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32n && pf_s32n_rtu_2]:
+
+EXTENSION class Kmem_alloc
+{
+  static constexpr unsigned long Rtu_heap_region_start = 0x3d580000;
+  static constexpr unsigned long Rtu_heap_region_end   = 0x3dffffff;
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32n && pf_s32n_rtu_3]:
+
+EXTENSION class Kmem_alloc
+{
+  static constexpr unsigned long Rtu_heap_region_start = 0x3f580000;
+  static constexpr unsigned long Rtu_heap_region_end   = 0x3fffffff;
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32n]:
+
+#include "kip.h"
+
+/**
+ * Constrain heap regions to RTU-local CRAM.
+ */
+IMPLEMENT_OVERRIDE static
+bool
+Kmem_alloc::validate_free_region(Kip const *kip, unsigned long *start,
+                                 unsigned long *end)
+{
+  (void)kip;
+
+  if (*start < Rtu_heap_region_start)
+    *start = Rtu_heap_region_start;
+
+  if (*end > Rtu_heap_region_end)
+    *end = Rtu_heap_region_end;
+
+  return *start < *end;
+}

--- a/src/kern/arm/bsp/s32n/mem_layout-arm-s32n.cpp
+++ b/src/kern/arm/bsp/s32n/mem_layout-arm-s32n.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && pf_s32n5]:
+
+EXTENSION class Mem_layout
+{
+public:
+  enum Mpu_layout { Mpu_regions = 24 };
+};
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && pf_s32n5 && pf_s32n_rtu_0]:
+
+EXTENSION class Mem_layout
+{
+public:
+  enum Phys_layout_s32: Address
+  {
+    Gic_phys_base      = 0x4b000000,
+    Rtu_Mru0           = 0x50470000,
+    Rtu_Mru1           = 0x505c0000,
+    Rtu_Mru2           = 0x50a20000,
+    Rtu_Mru3           = 0x50c00000,
+
+    // Map whole GIC
+    Gic_phys_size      =   0x200000,
+    Gic_redist_offset  =   0x100000,
+    Gic_redist_size    =   0x100000,
+
+    Mru_size           =    0x10000,
+  };
+};
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && pf_s32n5 && pf_s32n_rtu_1]:
+
+EXTENSION class Mem_layout
+{
+public:
+  enum Phys_layout_s32: Address
+  {
+    Gic_phys_base      = 0x4b400000,
+    Rtu_Mru0           = 0x51470000,
+    Rtu_Mru1           = 0x515c0000,
+    Rtu_Mru2           = 0x51a20000,
+    Rtu_Mru3           = 0x51c00000,
+
+    // Map whole GIC
+    Gic_phys_size      =   0x200000,
+    Gic_redist_offset  =   0x100000,
+    Gic_redist_size    =   0x100000,
+
+    Mru_size           =    0x10000,
+  };
+};
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && pf_s32n5 && pf_s32n_rtu_2]:
+
+EXTENSION class Mem_layout
+{
+public:
+  enum Phys_layout_s32: Address
+  {
+    Gic_phys_base      = 0x4b800000,
+    Rtu_Mru0           = 0x52470000,
+    Rtu_Mru1           = 0x525c0000,
+    Rtu_Mru2           = 0x52a20000,
+    Rtu_Mru3           = 0x52c00000,
+
+    // Map whole GIC
+    Gic_phys_size      =   0x200000,
+    Gic_redist_offset  =   0x100000,
+    Gic_redist_size    =   0x100000,
+
+    Mru_size           =    0x10000,
+  };
+};
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && pf_s32n5 && pf_s32n_rtu_3]:
+
+EXTENSION class Mem_layout
+{
+public:
+  enum Phys_layout_s32: Address
+  {
+    Gic_phys_base      = 0x4bc00000,
+    Rtu_Mru0           = 0x53470000,
+    Rtu_Mru1           = 0x535c0000,
+    Rtu_Mru2           = 0x53a20000,
+    Rtu_Mru3           = 0x53c00000,
+
+    // Map whole GIC
+    Gic_phys_size      =   0x200000,
+    Gic_redist_offset  =   0x100000,
+    Gic_redist_size    =   0x100000,
+
+    Mru_size           =    0x10000,
+  };
+};

--- a/src/kern/arm/bsp/s32n/mru-arm-s32n.cpp
+++ b/src/kern/arm/bsp/s32n/mru-arm-s32n.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+INTERFACE [arm && pf_s32n]:
+
+EXTENSION class Mru
+{
+  enum
+  {
+    Mru_ppi_int0_id = 17,
+    Mru_ppi_int1_id = 18,
+    Mru_ppi_int2_id = 19,
+    Mru_ppi_int3_id = 20,
+  };
+
+  enum
+  {
+    Notify0 = 0x200,
+    Notify1 = 0x204,
+    Notify2 = 0x208,
+    Notify3 = 0x20c,
+  };
+
+  struct Cfg1
+  {
+    Unsigned32 raw;
+    explicit Cfg1(Unsigned32 v) : raw(v) {}
+    CXX_BITFIELD_MEMBER(0, 15, mbic, raw);
+  };
+
+public:
+  enum { Nr_irqs = 12 };
+
+  explicit Mru(void *base, Irq_chip_gen *parent)
+  : Irq_chip_gen(Nr_irqs), Mmio_register_block(base),
+    _ppi0(this),
+    _ppi1(this),
+    _ppi2(this),
+    _ppi3(this)
+  {
+    init(Nr_irqs);
+
+    _ppi0.init(parent, Mru_ppi_int0_id);
+    _ppi1.init(parent, Mru_ppi_int1_id);
+    _ppi2.init(parent, Mru_ppi_int2_id);
+    _ppi3.init(parent, Mru_ppi_int3_id);
+  }
+
+private:
+  Mru_ppi _ppi0;
+  Mru_ppi _ppi1;
+  Mru_ppi _ppi2;
+  Mru_ppi _ppi3;
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32n]:
+
+PUBLIC
+Mword
+Mru::pending()
+{
+  Vmid_guard g;
+  return (read<Mword>(Notify0) | read<Mword>(Notify1)
+          | read<Mword>(Notify2) | read<Mword>(Notify3));
+}
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32n && pf_s32n_mru]:
+
+#include "kip.h"
+#include "kmem_mmio.h"
+
+PUBLIC static
+Mru *
+Mru::create_mru(Irq_chip_gen *parent)
+{
+  // The order is intentional because it matches the hardware mapping
+  static Address const mru_base[] =
+  {
+    Mem_layout::Rtu_Mru0, Mem_layout::Rtu_Mru2,
+    Mem_layout::Rtu_Mru1, Mem_layout::Rtu_Mru3,
+  };
+
+  Address mru_addr = mru_base[cxx::int_value<Amp_phys_id>(Amp_node::phys_id())];
+  Kip::k()->add_mem_region(Mem_desc(mru_addr,
+                                    mru_addr + Mem_layout::Mru_size - 1,
+                                    Mem_desc::Reserved));
+  void *mru_regs = Kmem_mmio::map(mru_addr, Mem_layout::Mru_size);
+
+  return new Boot_object<Mru>(mru_regs, parent);
+}
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32n && !pf_s32n_mru]:
+
+PUBLIC static inline
+Mru *
+Mru::create_mru(Irq_chip_gen *)
+{
+  return nullptr;
+}

--- a/src/kern/arm/bsp/s32n/pic-arm-s32n.cpp
+++ b/src/kern/arm/bsp/s32n/pic-arm-s32n.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+IMPLEMENTATION [arm && pic_gic && pf_s32n]:
+
+#include "gic.h"
+#include "gic_v3.h"
+#include "irq_mgr_multi_chip.h"
+#include "kmem_mmio.h"
+#include "cpu.h"
+#include "mru.h"
+
+PUBLIC static FIASCO_INIT
+void
+Pic::init()
+{
+  typedef Irq_mgr_multi_chip<10> M;
+  Mword id = Cpu::mpidr() & 0xffU;
+
+  void *dist_mmio = Kmem_mmio::map(Mem_layout::Gic_phys_base,
+                                   Mem_layout::Gic_phys_size);
+  void *redist_mmio = offset_cast<void *>(dist_mmio,
+                                          Mem_layout::Gic_redist_offset);
+
+  gic = new Boot_object<Gic_v3>(dist_mmio, redist_mmio, id == 0);
+
+  M *m = new Boot_object<M>(2);
+  m->add_chip(0, gic.unwrap(), gic->nr_pins());
+  if (auto *mru = Mru::create_mru(gic))
+    m->add_chip(1024, mru, Mru::Nr_irqs);
+
+  Irq_mgr::mgr = m;
+}

--- a/src/kern/arm/bsp/s32n/platform_control-arm-s32n.cpp
+++ b/src/kern/arm/bsp/s32n/platform_control-arm-s32n.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && amp && pf_s32n && pf_s32n_rtu_0]:
+
+EXTENSION class Platform_control
+{
+  static constexpr Mword tcm_bases[4] =
+  { 0x26000000, 0x26400000, 0x27000000, 0x27400000 };
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && amp && pf_s32n && pf_s32n_rtu_1]:
+
+EXTENSION class Platform_control
+{
+  static constexpr Mword tcm_bases[4] =
+  { 0x28000000, 0x28400000, 0x29000000, 0x29400000 };
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && amp && pf_s32n && pf_s32n_rtu_2]:
+
+EXTENSION class Platform_control
+{
+  static constexpr Mword tcm_bases[4] =
+  { 0x2A000000, 0x2A400000, 0x2B000000, 0x2B400000 };
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && amp && pf_s32n && pf_s32n_rtu_3]:
+
+EXTENSION class Platform_control
+{
+  static constexpr Mword tcm_bases[4] =
+  { 0x2C000000, 0x2C400000, 0x2D000000, 0x2D400000 };
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && amp && pf_s32n]:
+
+IMPLEMENT_OVERRIDE
+void
+Platform_control::amp_ap_early_init()
+{
+  // Setup core TCMs - IMP_xTCMREGIONR: ENABLEEL2=1, ENABLEEL10=1
+  Mword tcm_base = tcm_bases[cxx::int_value<Amp_phys_id>(Amp_node::phys_id())];
+  asm volatile ("mcr p15, 0, %0, c9, c1, 0" : : "r"(tcm_base | 0x00000003));
+  asm volatile ("mcr p15, 0, %0, c9, c1, 1" : : "r"(tcm_base | 0x00100003));
+  asm volatile ("mcr p15, 0, %0, c9, c1, 2" : : "r"(tcm_base | 0x00200003));
+}
+
+PUBLIC static void
+Platform_control::amp_boot_init()
+{
+  // Need to always start on first core of the expected cluster. Otherwise the
+  // GIC initialization or node memory assignment will fail.
+  assert(Amp_node::phys_id() == Amp_node::first_node());
+
+  amp_boot_ap_cpus(Amp_node::Max_cores);
+}
+
+static void
+setup_amp()
+{ Platform_control::amp_prepare_ap_cpus(); }
+
+STATIC_INITIALIZER_P(setup_amp, EARLY_INIT_PRIO);

--- a/src/kern/arm/bsp/s32n/reset-arm-s32n.cpp
+++ b/src/kern/arm/bsp/s32n/reset-arm-s32n.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+IMPLEMENTATION [arm && pf_s32n]:
+
+#include "infinite_loop.h"
+
+[[noreturn]] void
+platform_reset(void)
+{
+  L4::infinite_loop();
+}

--- a/src/kern/arm/bsp/s32n/timer-arm-generic-s32n.cpp
+++ b/src/kern/arm/bsp/s32n/timer-arm-generic-s32n.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023-2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+IMPLEMENTATION [arm_generic_timer && pf_s32n]:
+
+PUBLIC static
+unsigned Timer::irq()
+{
+  switch (Gtimer::Type)
+    {
+    case Generic_timer::Physical: return 30;
+    case Generic_timer::Virtual:  return 27;
+    case Generic_timer::Secure_hyp:
+    case Generic_timer::Hyp:      return 26;
+    };
+}
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm_generic_timer && pf_s32n && cpu_virt]:
+
+IMPLEMENT
+void Timer::bsp_init(Cpu_number)
+{
+  asm volatile ("mcr p15, 0, %0, c14, c0, 0" : : "r"(50000000)); // CNTFRQ
+}
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm_generic_timer && pf_s32n && !cpu_virt]:
+
+IMPLEMENT
+void Timer::bsp_init(Cpu_number)
+{ /* CNTFRQ can only be written on PL2. Assume that it's setup correctly. */ }


### PR DESCRIPTION
Introduce platform support for NXP S32N5 running on the RTU subsystem. This enables L4Re Microhypervisor bring‑up on RTU by adding BSP definitions and init hooks. RTU includes two clusters of Cortex‑R52 (2 cores each), configurable in lock‑step or split‑lock. AMP=y is supported across clusters.