### PR TITLE
arm: bsp: add NXP S32K5 platform support

### DIFF
--- a/src/kern/arm/bsp/s32k5/Kconfig
+++ b/src/kern/arm/bsp/s32k5/Kconfig
@@ -1,0 +1,13 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: MIT
+
+# PF: S32K5
+# PFDESCR: NXP S32K5
+# PFSELECT: CAN_ARM_CPU_CORTEX_R52 ARM_GIC HAVE_ARM_GICV3 HAS_PLAT_AMP_OPTION
+# PFDEPENDS: ARM
+
+config PF_S32K5_RAM_BASE
+	hex "Kernel load address"
+	default 0x22000000
+	help
+	  Start address of the kernel image. Defaults to start of CPE SRAM0.

--- a/src/kern/arm/bsp/s32k5/Modules
+++ b/src/kern/arm/bsp/s32k5/Modules
@@ -1,0 +1,23 @@
+# Copyright 2025 NXP
+# SPDX-License-Identifier: MIT
+
+# vim:set ft=make:
+
+OBJECTS_LIBUART       += uart_dcc-v6.o
+CXXFLAGS_uart-libuart += $(call LIBUART_UART, dcc-v6, dcc_v6)
+
+PREPROCESS_PARTS      += generic_tickless_idle arm_generic_timer pic_gic
+INTERFACES_KERNEL     += generic_timer irq_mgr_multi_chip
+
+RAM_PHYS_BASE         := $(CONFIG_PF_S32K5_RAM_BASE)
+
+amp_node_IMPL         := amp_node amp_node-arm-s32k5
+config_IMPL           += config-arm-s32k5
+kmem_alloc_IMPL       += kmem_alloc-arm-s32k5
+mem_layout_IMPL       += mem_layout-arm-s32k5
+pic_IMPL              += pic-gic pic-arm-s32k5
+timer_IMPL            += timer-arm-generic timer-arm-generic-s32k5
+timer_tick_IMPL       += timer_tick-single-vector
+reset_IMPL            += reset-arm-s32k5
+clock_IMPL            += clock-arm-generic
+platform_control_IMPL += platform_control-arm-s32k5

--- a/src/kern/arm/bsp/s32k5/amp_node-arm-s32k5.cpp
+++ b/src/kern/arm/bsp/s32k5/amp_node-arm-s32k5.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// ------------------------------------------------------------------------
+INTERFACE [arm && amp && pf_s32k5]:
+
+EXTENSION class Amp_node
+{
+public:
+  static constexpr unsigned Max_cores = 2;
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && amp && pf_s32k5]:
+
+#include "processor.h"
+
+IMPLEMENT inline ALWAYS_INLINE NEEDS["processor.h"]
+FIASCO_PURE Amp_phys_id
+Amp_node::phys_id()
+{
+  // Aff0: 0..1 - core in cluster
+  // Aff1: 0    - cluster in CPE, always 0
+  // Aff2: 0    - CPE in SoC, always 0
+  unsigned mpidr = cxx::int_value<Cpu_phys_id>(Proc::cpu_id());
+  return Amp_phys_id(mpidr & 0x1);
+}

--- a/src/kern/arm/bsp/s32k5/config-arm-s32k5.cpp
+++ b/src/kern/arm/bsp/s32k5/config-arm-s32k5.cpp
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+INTERFACE [arm && pf_s32k5]:
+
+#define TARGET_NAME "NXP S32K5"

--- a/src/kern/arm/bsp/s32k5/kmem_alloc-arm-s32k5.cpp
+++ b/src/kern/arm/bsp/s32k5/kmem_alloc-arm-s32k5.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32k5]:
+
+EXTENSION class Kmem_alloc
+{
+  static constexpr unsigned long Cpe_heap_region_start = 0x22000000;
+  static constexpr unsigned long Cpe_heap_region_end   = 0x220FFFFF;
+};
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && pf_s32k5]:
+
+#include "kip.h"
+
+/**
+ * Constrain heap regions to CPE local SRAM.
+ */
+IMPLEMENT_OVERRIDE static
+bool
+Kmem_alloc::validate_free_region(Kip const *kip, unsigned long *start,
+                                 unsigned long *end)
+{
+  (void)kip;
+
+  if (*start < Cpe_heap_region_start)
+    *start = Cpe_heap_region_start;
+
+  if (*end > Cpe_heap_region_end)
+    *end = Cpe_heap_region_end;
+
+  return *start < *end;
+}

--- a/src/kern/arm/bsp/s32k5/mem_layout-arm-s32k5.cpp
+++ b/src/kern/arm/bsp/s32k5/mem_layout-arm-s32k5.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// ----------------------------------------------------------------------------
+INTERFACE [arm && pf_s32k5]:
+
+EXTENSION class Mem_layout
+{
+public:
+  enum Mpu_layout { Mpu_regions = 20 };
+
+  enum Phys_layout_s32: Address
+  {
+    Gic_phys_base      = 0x43000000,
+
+    /* Map whole GIC */
+    Gic_phys_size      =   0x200000,
+    Gic_redist_offset  =   0x100000,
+    Gic_redist_size    =   0x100000,
+  };
+};

--- a/src/kern/arm/bsp/s32k5/pic-arm-s32k5.cpp
+++ b/src/kern/arm/bsp/s32k5/pic-arm-s32k5.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+IMPLEMENTATION [arm && pic_gic && pf_s32k5]:
+
+#include "gic.h"
+#include "gic_v3.h"
+#include "irq_mgr_multi_chip.h"
+#include "kmem_mmio.h"
+#include "cpu.h"
+
+PUBLIC static FIASCO_INIT
+void
+Pic::init()
+{
+  typedef Irq_mgr_multi_chip<10> M;
+  Mword id = Cpu::mpidr() & 0xffU;
+
+  void *dist_mmio = Kmem_mmio::map(Mem_layout::Gic_phys_base,
+                                   Mem_layout::Gic_phys_size);
+  void *redist_mmio = offset_cast<void *>(dist_mmio,
+                                          Mem_layout::Gic_redist_offset);
+
+  gic = new Boot_object<Gic_v3>(dist_mmio, redist_mmio, id == 0);
+
+  M *m = new Boot_object<M>(1);
+  m->add_chip(0, gic.unwrap(), gic->nr_pins());
+
+  Irq_mgr::mgr = m;
+}

--- a/src/kern/arm/bsp/s32k5/platform_control-arm-s32k5.cpp
+++ b/src/kern/arm/bsp/s32k5/platform_control-arm-s32k5.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm && amp && pf_s32k5]:
+
+#include "panic.h"
+
+IMPLEMENT_OVERRIDE
+void
+Platform_control::amp_ap_early_init()
+{
+  // Enable LLPP peripheral port at EL2 and EL1/0
+  unsigned long imp_periphpregionr;
+  asm volatile ("mrc p15, 0, %0, c15, c0, 0" : "=r"(imp_periphpregionr));
+  imp_periphpregionr |= 3;
+  asm volatile ("mcr p15, 0, %0, c15, c0, 0" : : "r"(imp_periphpregionr));
+
+  // Setup core TCMs
+  Mword tcm_base = 0;
+  if (Amp_node::phys_id() == Amp_phys_id{0})
+    tcm_base = 0x01000000;
+  else if (Amp_node::phys_id() == Amp_phys_id{1})
+    tcm_base = 0x01400000;
+  else
+    panic("Running on invalid core!\n");
+
+  // IMP_xTCMREGIONR. ENABLEEL2=1, ENABLEEL10=1
+  asm volatile ("mcr p15, 0, %0, c9, c1, 0" : : "r"(tcm_base | 0x00000003));
+  asm volatile ("mcr p15, 0, %0, c9, c1, 1" : : "r"(tcm_base | 0x00100003));
+  asm volatile ("mcr p15, 0, %0, c9, c1, 2" : : "r"(tcm_base | 0x00200003));
+}
+
+PUBLIC static void
+Platform_control::amp_boot_init()
+{
+  // Need to always start on first core of the expected cluster. Otherwise the
+  // GIC initialization or node memory assignment will fail.
+  assert(Amp_node::phys_id() == Amp_node::first_node());
+
+  amp_boot_ap_cpus(Amp_node::Max_cores);
+}
+
+static void
+setup_amp()
+{ Platform_control::amp_prepare_ap_cpus(); }
+
+STATIC_INITIALIZER_P(setup_amp, EARLY_INIT_PRIO);

--- a/src/kern/arm/bsp/s32k5/reset-arm-s32k5.cpp
+++ b/src/kern/arm/bsp/s32k5/reset-arm-s32k5.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+IMPLEMENTATION [arm && pf_s32k5]:
+
+#include "infinite_loop.h"
+
+[[noreturn]] void
+platform_reset(void)
+{
+  L4::infinite_loop();
+}

--- a/src/kern/arm/bsp/s32k5/timer-arm-generic-s32k5.cpp
+++ b/src/kern/arm/bsp/s32k5/timer-arm-generic-s32k5.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 NXP
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+IMPLEMENTATION [arm_generic_timer && pf_s32k5]:
+
+PUBLIC static
+unsigned Timer::irq()
+{
+  switch (Gtimer::Type)
+    {
+    case Generic_timer::Physical: return 30;
+    case Generic_timer::Virtual:  return 27;
+    case Generic_timer::Secure_hyp:
+    case Generic_timer::Hyp:      return 26;
+    };
+}
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm_generic_timer && pf_s32k5 && cpu_virt]:
+
+IMPLEMENT
+void Timer::bsp_init(Cpu_number)
+{
+  // Set CNTFRQ. CPE's generic timer is clocked from:
+  // SAFE_CLK / CPE_GPR.CR52_CNT_DIV = 50MHz / 4 (default reset value)
+  asm volatile ("mcr p15, 0, %0, c14, c0, 0" : : "r"(12500000));
+}
+
+// ------------------------------------------------------------------------
+IMPLEMENTATION [arm_generic_timer && pf_s32k5 && !cpu_virt]:
+
+IMPLEMENT
+void Timer::bsp_init(Cpu_number)
+{ /* CNTFRQ can only be written on PL2. Assume that it's setup correctly. */ }


### PR DESCRIPTION
Add platform support for NXP S32K5 running on the CPE subsystem. This includes BSP definitions and initialization hooks required for L4Re Microhypervisor bring-up on CPE.

The CPE subsystem features a single Cortex-R52 cluster with two cores operating in split-lock mode. Single core and AMP is supported. Unlike other NXP S32 platforms, CPE MRU instances route interrupts as GIC SPIs, so MRU virtualization is not required.
